### PR TITLE
Fix openstef reference part 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - "influxdb"
     command: >
       sh -c "apt-get update &&
+      pip install --upgrade pip &&
       apt-get install make automake gcc g++ subversion python3-dev &&      
       pip install pandas influxdb-client openstf-dbc &&
       cd /opt/influxdb-configurator/ &&
@@ -60,6 +61,9 @@ services:
       "
     volumes:
       - ./influxdb-configurator:/opt/influxdb-configurator
+    build:
+      context: .
+      shm_size: '250mb'
   nginx:
     image: nginx
     container_name: openstf-nginx

--- a/influxdb-configurator/load_data_to_influx.py
+++ b/influxdb-configurator/load_data_to_influx.py
@@ -103,6 +103,7 @@ def load_weather_data(delta):
 
 if __name__ == "__main__":
     config = ConfigManager.load_project_config(project_root=PROJECT_ROOT).get_instance()
+    _DataInterface(config)
     result, delta = load_load_data()
     load_t_ahead_data(delta)
     load_weather_data(delta)


### PR DESCRIPTION
Updated docker-compose.yml:
1) Added "pip install --upgrade pip" to the influx-configurator command
2) Set the shm_size of influx-configurator to 250mb

Signed-off-by: Jonas van den Bogaard Jonas.van.den.bogaard@alliander.com